### PR TITLE
refactor(certificates): Define explicit data types for certificate payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ nul
 package-lock.json
 video_2026-03-19_23-12-10.mp4
 GEMINI.md
+QWEN.md

--- a/src/app/feature/certificate/certificate-option.interface.ts
+++ b/src/app/feature/certificate/certificate-option.interface.ts
@@ -1,5 +1,11 @@
 import { CrudDocument } from 'wacom';
 
+export interface CertificateOptionData {
+	title: string;
+	description: string;
+	templateStyle: 'classic' | 'modern' | 'minimalist';
+}
+
 export interface CertificateOption extends CrudDocument<CertificateOption> {
-	data?: Record<string, any>;
+	data?: CertificateOptionData;
 }

--- a/src/app/feature/certificate/certificate-option.service.ts
+++ b/src/app/feature/certificate/certificate-option.service.ts
@@ -30,11 +30,26 @@ export class CertificateOptionService {
 	}
 
 	new(): Partial<CertificateOption> {
-		return { data: {} };
+		return {
+			data: {
+				title: '',
+				description: '',
+				templateStyle: 'classic',
+			},
+		};
 	}
 
 	create(option: Partial<CertificateOption>): Observable<CertificateOption | null> {
-		return this._http.post('/api/itcertificateoption/create', option).pipe(
+		const data = option.data;
+		const payload = {
+			...option,
+			data: {
+				title: data?.title || '',
+				description: data?.description || '',
+				templateStyle: data?.templateStyle || 'classic',
+			},
+		};
+		return this._http.post('/api/itcertificateoption/create', payload).pipe(
 			map((res: unknown) => res ? (res as CertificateOption) : null),
 			tap(newOpt => {
 				if (newOpt) {
@@ -46,10 +61,16 @@ export class CertificateOptionService {
 	}
 
 	update(option: CertificateOption): Observable<CertificateOption | null> {
-		return this._http.post('/api/itcertificateoption/update', {
+		const data = option.data;
+		const payload = {
 			_id: option._id,
-			data: option.data
-		}).pipe(
+			data: {
+				title: data?.title || '',
+				description: data?.description || '',
+				templateStyle: data?.templateStyle || 'classic',
+			},
+		};
+		return this._http.post('/api/itcertificateoption/update', payload).pipe(
 			map((res: unknown) => res ? (res as CertificateOption) : null),
 			tap(updatedOpt => {
 				if (updatedOpt) {
@@ -73,7 +94,7 @@ export class CertificateOptionService {
 	}
 
 	private _seedDemoOptions() {
-		const demoOptions = [
+		const demoOptions: Partial<CertificateOption>[] = [
 			{
 				data: {
 					title: 'Сертифікат про завершення курсу',

--- a/src/app/feature/certificate/certificate-pdf.service.ts
+++ b/src/app/feature/certificate/certificate-pdf.service.ts
@@ -26,19 +26,19 @@ export class CertificatePdfService {
 		}
 
 		const definition = await this._buildDocDefinition(certificate);
-		const fileName = `Certificate_${certificate.data?.['recipientName'] || 'document'}.pdf`.replace(/\s+/g, '_');
+		const fileName = `Certificate_${certificate.data?.recipientName || 'document'}.pdf`.replace(/\s+/g, '_');
 		(pdfMake.createPdf(definition as any) as any).download(fileName);
 	}
 
 	private async _buildDocDefinition(cert: Certificate): Promise<Record<string, unknown>> {
-		const data = cert.data || {};
-		const style = data['templateStyle'] || 'classic';
-		
+		const data = cert.data;
+		const style = data?.templateStyle || 'classic';
+
 		// Common data
-		const title = data['title'] || 'CERTIFICATE OF COMPLETION';
-		const recipient = data['recipientName'] || 'Recipient Name';
-		const description = data['description'] || 'For successful completion of the requirements set forth by IT Kamianets.';
-		const date = data['issueDate'] ? new Date(data['issueDate']).toLocaleDateString('uk-UA') : new Date().toLocaleDateString('uk-UA');
+		const title = data?.title || 'CERTIFICATE OF COMPLETION';
+		const recipient = data?.recipientName || 'Recipient Name';
+		const description = data?.description || 'For successful completion of the requirements set forth by IT Kamianets.';
+		const date = data?.issueDate ? new Date(data.issueDate).toLocaleDateString('uk-UA') : new Date().toLocaleDateString('uk-UA');
 
 		if (style === 'modern') {
 			return this._buildModernDefinition(title, recipient, description, date);

--- a/src/app/feature/certificate/certificate.interface.ts
+++ b/src/app/feature/certificate/certificate.interface.ts
@@ -1,7 +1,15 @@
 import { CrudDocument } from 'wacom';
 
+export interface CertificateData {
+	title: string;
+	recipientName: string;
+	description: string;
+	issueDate: string;
+	templateStyle: 'classic' | 'modern' | 'minimalist';
+}
+
 export interface Certificate extends CrudDocument<Certificate> {
 	name?: string;
 	description?: string;
-	data?: Record<string, any>;
+	data?: CertificateData;
 }

--- a/src/app/feature/certificate/certificate.service.ts
+++ b/src/app/feature/certificate/certificate.service.ts
@@ -8,7 +8,7 @@ import { Certificate } from './certificate.interface';
 })
 export class CertificateService {
 	private readonly _http = inject(HttpService);
-	
+
 	private readonly _certificates = signal<Certificate[]>([]);
 	readonly docs = this._certificates.asReadonly();
 
@@ -35,14 +35,30 @@ export class CertificateService {
 	}
 
 	new(): Partial<Certificate> {
-		return { data: {} };
+		return {
+			data: {
+				title: '',
+				recipientName: '',
+				description: '',
+				issueDate: '',
+				templateStyle: 'classic',
+			},
+		};
 	}
 
 	create(cert: Partial<Certificate>): Observable<Certificate | null> {
+		const data = cert.data;
 		const payload = {
 			...cert,
-			name: cert.data?.['recipientName'] || '',
-			description: cert.data?.['title'] || ''
+			name: data?.recipientName || '',
+			description: data?.title || '',
+			data: {
+				title: data?.title || '',
+				recipientName: data?.recipientName || '',
+				description: data?.description || '',
+				issueDate: data?.issueDate || '',
+				templateStyle: data?.templateStyle || 'classic',
+			},
 		};
 		return this._http.post('/api/itcertificate/create', payload).pipe(
 			map((res: unknown) => res ? (res as Certificate) : null),
@@ -56,9 +72,16 @@ export class CertificateService {
 	}
 
 	update(cert: Certificate): Observable<Certificate | null> {
+		const data = cert.data;
 		const payload = {
 			_id: cert._id,
-			data: cert.data
+			data: {
+				title: data?.title || '',
+				recipientName: data?.recipientName || '',
+				description: data?.description || '',
+				issueDate: data?.issueDate || '',
+				templateStyle: data?.templateStyle || 'classic',
+			},
 		};
 		return this._http.post('/api/itcertificate/update', payload).pipe(
 			map((res: unknown) => res ? (res as Certificate) : null),

--- a/src/app/feature/certificate/pages/certificate/certificate.component.html
+++ b/src/app/feature/certificate/pages/certificate/certificate.component.html
@@ -7,7 +7,7 @@
 		</header>
 
 		@if (certificate()) {
-			@switch (certificate()!.data?.['templateStyle']) {
+			@switch (certificate()!.data?.templateStyle) {
 				@case ('modern') {
 					<!-- MODERN STYLE -->
 					<div class="certificate-container relative bg-slate-900 border border-slate-700 p-10 md:p-16 rounded-[2rem] shadow-2xl overflow-hidden text-center text-white">
@@ -24,7 +24,7 @@
 							</p>
 
 							<h1 class="text-4xl md:text-5xl font-black bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-indigo-400 to-fuchsia-400 mb-6 leading-tight">
-								{{ certificate()!.data?.['title'] || 'Документ без назви' }}
+								{{ certificate()!.data?.title || 'Документ без назви' }}
 							</h1>
 
 							<p class="text-slate-400 mb-8 max-w-xl mx-auto uppercase tracking-widest text-[10px] font-bold">
@@ -32,12 +32,12 @@
 							</p>
 
 							<p class="text-3xl md:text-5xl font-bold text-white mb-10 tracking-wide">
-								{{ certificate()!.data?.['recipientName'] || 'Отримувач не вказаний' }}
+								{{ certificate()!.data?.recipientName || 'Отримувач не вказаний' }}
 							</p>
 
-							@if (certificate()!.data?.['description']) {
+							@if (certificate()!.data?.description) {
 								<p class="text-lg text-slate-300 max-w-2xl mx-auto mb-12 leading-relaxed whitespace-pre-line bg-slate-800/50 p-6 rounded-2xl border border-slate-700/50 shadow-inner">
-									{{ certificate()!.data?.['description'] }}
+									{{ certificate()!.data?.description }}
 								</p>
 							}
 
@@ -48,12 +48,12 @@
 										{{ certificate()!._id }}
 									</span>
 								</div>
-								
-								@if (certificate()!.data?.['issueDate']) {
+
+								@if (certificate()!.data?.issueDate) {
 									<div class="text-right flex flex-col gap-1">
 										<span class="text-[10px] font-bold text-indigo-400 uppercase tracking-widest">Дата видачі</span>
 										<span class="font-medium text-slate-300">
-											{{ certificate()!.data?.['issueDate'] | date: 'longDate' }}
+											{{ certificate()!.data?.issueDate | date: 'longDate' }}
 										</span>
 									</div>
 								}
@@ -67,7 +67,7 @@
 						<div class="w-12 h-1 bg-black mx-auto mb-16"></div>
 
 						<h1 class="text-3xl md:text-5xl font-light text-black tracking-wide mb-12">
-							{{ certificate()!.data?.['title'] || 'Документ без назви' }}
+							{{ certificate()!.data?.title || 'Документ без назви' }}
 						</h1>
 
 						<p class="text-sm text-slate-400 uppercase tracking-[0.2em] mb-4">
@@ -75,12 +75,12 @@
 						</p>
 
 						<p class="text-3xl md:text-4xl font-serif text-black mb-12">
-							{{ certificate()!.data?.['recipientName'] || 'Отримувач не вказаний' }}
+							{{ certificate()!.data?.recipientName || 'Отримувач не вказаний' }}
 						</p>
 
-						@if (certificate()!.data?.['description']) {
+						@if (certificate()!.data?.description) {
 							<p class="text-md text-slate-600 max-w-lg mx-auto mb-20 font-light leading-relaxed whitespace-pre-line">
-								{{ certificate()!.data?.['description'] }}
+								{{ certificate()!.data?.description }}
 							</p>
 						}
 
@@ -89,11 +89,11 @@
 								<p class="text-xs text-slate-400 mb-1">ID</p>
 								<p class="font-mono text-xs text-black">{{ certificate()!._id }}</p>
 							</div>
-							
-							@if (certificate()!.data?.['issueDate']) {
+
+							@if (certificate()!.data?.issueDate) {
 								<div class="text-right border-b border-black pb-2 px-4">
 									<p class="text-sm font-light text-black">
-										{{ certificate()!.data?.['issueDate'] | date: 'longDate' }}
+										{{ certificate()!.data?.issueDate | date: 'longDate' }}
 									</p>
 								</div>
 							}
@@ -107,26 +107,26 @@
 							<div class="w-24 h-24 mx-auto border-2 border-amber-400 dark:border-amber-600 rounded-full flex items-center justify-center text-4xl mb-8 text-amber-600 dark:text-amber-500">
 								<span class="material-symbols-outlined text-4xl" aria-hidden="true">school</span>
 							</div>
-							
+
 							<p class="uppercase tracking-widest text-amber-700 dark:text-amber-500 font-bold mb-4 text-xs font-serif">
 								Офіційний документ
 							</p>
 
 							<h1 class="text-4xl md:text-5xl font-serif text-slate-900 dark:text-amber-50 mb-6 leading-tight">
-								{{ certificate()!.data?.['title'] || 'Документ без назви' }}
+								{{ certificate()!.data?.title || 'Документ без назви' }}
 							</h1>
-							
+
 							<p class="text-lg text-slate-600 dark:text-amber-200/70 mb-8 max-w-xl mx-auto font-serif italic">
 								Нагороджується
 							</p>
 
 							<p class="text-3xl md:text-5xl font-serif font-bold text-amber-800 dark:text-amber-400 mb-12 border-b border-amber-300 dark:border-amber-700/50 pb-4 px-12 inline-block">
-								{{ certificate()!.data?.['recipientName'] || 'Отримувач не вказаний' }}
+								{{ certificate()!.data?.recipientName || 'Отримувач не вказаний' }}
 							</p>
 
-							@if (certificate()!.data?.['description']) {
+							@if (certificate()!.data?.description) {
 								<p class="text-lg text-slate-700 dark:text-amber-100/80 max-w-2xl mx-auto mb-16 leading-relaxed whitespace-pre-line font-serif">
-									{{ certificate()!.data?.['description'] }}
+									{{ certificate()!.data?.description }}
 								</p>
 							}
 
@@ -137,12 +137,12 @@
 										{{ certificate()!._id }}
 									</p>
 								</div>
-								
-								@if (certificate()!.data?.['issueDate']) {
+
+								@if (certificate()!.data?.issueDate) {
 									<div class="text-right font-serif">
 										<p class="text-xs text-slate-500 dark:text-amber-400/60 uppercase tracking-widest mb-1">Дата видачі</p>
 										<p class="font-medium text-slate-800 dark:text-amber-200">
-											{{ certificate()!.data?.['issueDate'] | date: 'longDate' }}
+											{{ certificate()!.data?.issueDate | date: 'longDate' }}
 										</p>
 									</div>
 								}

--- a/src/app/feature/certificate/pages/manage-certificates/manage-certificates.component.html
+++ b/src/app/feature/certificate/pages/manage-certificates/manage-certificates.component.html
@@ -42,7 +42,7 @@
 							<select [ngModel]="selectedTemplateId()" (change)="applyTemplate($any($event.target).value)" class="w-full px-4 py-2 rounded-xl border border-[var(--c-border)] bg-[var(--c-bg-tertiary)] text-[var(--c-text-primary)] focus:border-[var(--c-primary)] outline-none transition-all">
 								<option value="">-- Оберіть шаблон (опціонально) --</option>
 								@for (opt of options(); track opt._id) {
-									<option [value]="opt._id">{{ opt.data?.['title'] || opt._id }}</option>
+									<option [value]="opt._id">{{ opt.data?.title || opt._id }}</option>
 								}
 							</select>
 						</div>
@@ -99,26 +99,26 @@
 								@for (cert of certificates(); track cert._id) {
 									<tr class="hover:bg-[var(--c-bg-tertiary)] transition-colors">
 										<td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-[var(--c-text-primary)] sm:pl-6">
-											{{ cert.data?.['recipientName'] || 'Невідомий отримувач' }}
+											{{ cert.data?.recipientName || 'Невідомий отримувач' }}
 										</td>
 										<td class="whitespace-nowrap px-3 py-4 text-sm text-[var(--c-text-muted)]">
-											{{ cert.data?.['title'] || 'Без назви' }}
+											{{ cert.data?.title || 'Без назви' }}
 										</td>
 										<td class="whitespace-nowrap px-3 py-4 text-sm text-[var(--c-text-muted)]">
-											{{ cert.data?.['issueDate'] | date: 'dd.MM.yyyy' }}
+											{{ cert.data?.issueDate | date: 'dd.MM.yyyy' }}
 										</td>
 										<td class="whitespace-nowrap px-3 py-4 text-sm">
-											<span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset" 
-												[class.bg-blue-500/10]="cert.data?.['templateStyle'] === 'modern'"
-												[class.text-blue-500]="cert.data?.['templateStyle'] === 'modern'"
-												[class.ring-blue-500/20]="cert.data?.['templateStyle'] === 'modern'"
-												[class.bg-amber-500/10]="cert.data?.['templateStyle'] === 'classic'"
-												[class.text-amber-500]="cert.data?.['templateStyle'] === 'classic'"
-												[class.ring-amber-500/20]="cert.data?.['templateStyle'] === 'classic'"
-												[class.bg-slate-500/10]="cert.data?.['templateStyle'] === 'minimalist'"
-												[class.text-slate-500]="cert.data?.['templateStyle'] === 'minimalist'"
-												[class.ring-slate-500/20]="cert.data?.['templateStyle'] === 'minimalist'">
-												{{ cert.data?.['templateStyle'] || 'default' }}
+											<span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset"
+												[class.bg-blue-500/10]="cert.data?.templateStyle === 'modern'"
+												[class.text-blue-500]="cert.data?.templateStyle === 'modern'"
+												[class.ring-blue-500/20]="cert.data?.templateStyle === 'modern'"
+												[class.bg-amber-500/10]="cert.data?.templateStyle === 'classic'"
+												[class.text-amber-500]="cert.data?.templateStyle === 'classic'"
+												[class.ring-amber-500/20]="cert.data?.templateStyle === 'classic'"
+												[class.bg-slate-500/10]="cert.data?.templateStyle === 'minimalist'"
+												[class.text-slate-500]="cert.data?.templateStyle === 'minimalist'"
+												[class.ring-slate-500/20]="cert.data?.templateStyle === 'minimalist'">
+												{{ cert.data?.templateStyle || 'default' }}
 											</span>
 										</td>
 										<td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">

--- a/src/app/feature/certificate/pages/manage-certificates/manage-certificates.component.ts
+++ b/src/app/feature/certificate/pages/manage-certificates/manage-certificates.component.ts
@@ -5,7 +5,7 @@ import { RouterLink } from '@angular/router';
 import { CertificateService } from '../../certificate.service';
 import { CertificateOptionService } from '../../certificate-option.service';
 import { CertificatePdfService } from '../../certificate-pdf.service';
-import { Certificate } from '../../certificate.interface';
+import { Certificate, CertificateData } from '../../certificate.interface';
 
 @Component({
 	selector: 'app-manage-certificates',
@@ -20,7 +20,7 @@ export class ManageCertificatesComponent {
 	private readonly _optionService = inject(CertificateOptionService);
 	private readonly _pdfService = inject(CertificatePdfService);
 	private readonly _cdr = inject(ChangeDetectorRef);
-	
+
 	protected readonly certificates = this._certService.docs;
 	protected readonly options = this._optionService.docs;
 
@@ -30,7 +30,7 @@ export class ManageCertificatesComponent {
 
 	protected readonly editingCert = signal<Certificate | null>(null);
 	protected readonly selectedTemplateId = signal<string>('');
-	protected readonly form = signal({
+	protected readonly form = signal<CertificateData>({
 		title: '',
 		recipientName: '',
 		description: '',
@@ -61,19 +61,19 @@ export class ManageCertificatesComponent {
 	}
 
 	protected edit(cert: Certificate) {
-		const data = cert.data || {};
+		const data = cert.data;
 		this.form.set({
-			title: data['title'] || '',
-			recipientName: data['recipientName'] || '',
-			description: data['description'] || '',
-			issueDate: data['issueDate'] ? this._toDateTimeLocal(data['issueDate']) : '',
-			templateStyle: data['templateStyle'] || 'classic'
+			title: data?.title || '',
+			recipientName: data?.recipientName || '',
+			description: data?.description || '',
+			issueDate: data?.issueDate ? this._toDateTimeLocal(data.issueDate) : '',
+			templateStyle: data?.templateStyle || 'classic'
 		});
 		this.selectedTemplateId.set('');
 		this.editingCert.set(cert);
 	}
 
-	protected updateFormField(field: string, value: any) {
+	protected updateFormField(field: keyof CertificateData, value: string) {
 		this.form.update(f => ({ ...f, [field]: value }));
 	}
 
@@ -123,12 +123,13 @@ export class ManageCertificatesComponent {
 	protected applyTemplate(optionId: string) {
 		this.selectedTemplateId.set(optionId);
 		const opt = this.options().find(o => o._id === optionId);
-		if (opt && opt.data) {
+		const data = opt?.data;
+		if (data) {
 			this.form.update(f => ({
 				...f,
-				title: opt.data?.['title'] || f.title,
-				description: opt.data?.['description'] || f.description,
-				templateStyle: opt.data?.['templateStyle'] || f.templateStyle
+				title: data.title || f.title,
+				description: data.description || f.description,
+				templateStyle: data.templateStyle || f.templateStyle
 			}));
 			this._cdr.markForCheck();
 		}

--- a/src/app/feature/certificate/pages/manage-options/manage-options.component.html
+++ b/src/app/feature/certificate/pages/manage-options/manage-options.component.html
@@ -83,23 +83,23 @@
 								@for (opt of options(); track opt._id) {
 									<tr class="hover:bg-[var(--c-bg-tertiary)] transition-colors">
 										<td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-[var(--c-text-primary)] sm:pl-6">
-											{{ opt.data?.['title'] || 'Без назви' }}
+											{{ opt.data?.title || 'Без назви' }}
 										</td>
 										<td class="px-3 py-4 text-sm text-[var(--c-text-muted)] max-w-xs truncate">
-											{{ opt.data?.['description'] || 'Без опису' }}
+											{{ opt.data?.description || 'Без опису' }}
 										</td>
 										<td class="whitespace-nowrap px-3 py-4 text-sm">
-											<span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset" 
-												[class.bg-blue-500/10]="opt.data?.['templateStyle'] === 'modern'"
-												[class.text-blue-500]="opt.data?.['templateStyle'] === 'modern'"
-												[class.ring-blue-500/20]="opt.data?.['templateStyle'] === 'modern'"
-												[class.bg-amber-500/10]="opt.data?.['templateStyle'] === 'classic'"
-												[class.text-amber-500]="opt.data?.['templateStyle'] === 'classic'"
-												[class.ring-amber-500/20]="opt.data?.['templateStyle'] === 'classic'"
-												[class.bg-slate-500/10]="opt.data?.['templateStyle'] === 'minimalist'"
-												[class.text-slate-500]="opt.data?.['templateStyle'] === 'minimalist'"
-												[class.ring-slate-500/20]="opt.data?.['templateStyle'] === 'minimalist'">
-												{{ opt.data?.['templateStyle'] || 'default' }}
+											<span class="inline-flex items-center rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset"
+												[class.bg-blue-500/10]="opt.data?.templateStyle === 'modern'"
+												[class.text-blue-500]="opt.data?.templateStyle === 'modern'"
+												[class.ring-blue-500/20]="opt.data?.templateStyle === 'modern'"
+												[class.bg-amber-500/10]="opt.data?.templateStyle === 'classic'"
+												[class.text-amber-500]="opt.data?.templateStyle === 'classic'"
+												[class.ring-amber-500/20]="opt.data?.templateStyle === 'classic'"
+												[class.bg-slate-500/10]="opt.data?.templateStyle === 'minimalist'"
+												[class.text-slate-500]="opt.data?.templateStyle === 'minimalist'"
+												[class.ring-slate-500/20]="opt.data?.templateStyle === 'minimalist'">
+												{{ opt.data?.templateStyle || 'default' }}
 											</span>
 										</td>
 										<td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">

--- a/src/app/feature/certificate/pages/manage-options/manage-options.component.ts
+++ b/src/app/feature/certificate/pages/manage-options/manage-options.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, inject, signal, ChangeDetectorRef }
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { CertificateOptionService } from '../../certificate-option.service';
-import { CertificateOption } from '../../certificate-option.interface';
+import { CertificateOption, CertificateOptionData } from '../../certificate-option.interface';
 
 @Component({
 	selector: 'app-manage-options',
@@ -26,7 +26,7 @@ export class ManageOptionsComponent {
 	}
 
 	protected readonly editingOption = signal<CertificateOption | null>(null);
-	protected form = {
+	protected form: CertificateOptionData = {
 		title: '',
 		description: '',
 		templateStyle: 'classic'
@@ -42,11 +42,11 @@ export class ManageOptionsComponent {
 	}
 
 	protected edit(option: CertificateOption) {
-		const data = option.data || {};
+		const data = option.data;
 		this.form = {
-			title: data['title'] || '',
-			description: data['description'] || '',
-			templateStyle: data['templateStyle'] || 'classic'
+			title: data?.title || '',
+			description: data?.description || '',
+			templateStyle: data?.templateStyle || 'classic'
 		};
 		this.editingOption.set(option);
 	}


### PR DESCRIPTION
## Summary

Replace loose `Record<string, any>` with strongly-typed `CertificateData` and `CertificateOptionData` interfaces. This ensures the backend receives explicit, predictable field names in request bodies and eliminates bracket-access anti-patterns throughout the feature.

## Problem

The `Certificate` and `CertificateOption` interfaces used `data?: Record<string, any>`, which meant:

- The backend received untyped payloads that were hard to validate
- Form data was accessed via `data['fieldName']` instead of typed dot notation
- No compile-time safety for field names or their types
- Easy to introduce typos or miss fields in create/update requests

## Solution

### New typed interfaces

```typescript
interface CertificateData {
  title: string;
  recipientName: string;
  description: string;
  issueDate: string;
  templateStyle: 'classic' | 'modern' | 'minimalist';
}

interface CertificateOptionData {
  title: string;
  description: string;
  templateStyle: 'classic' | 'modern' | 'minimalist';
}
```

### Changes

| File | Change |
|------|--------|
| `certificate.interface.ts` | Added `CertificateData` interface; `data` typed as `CertificateData` |
| `certificate-option.interface.ts` | Added `CertificateOptionData` interface; `data` typed as `CertificateOptionData` |
| `certificate.service.ts` | `create()` and `update()` build explicit typed payloads; `new()` returns typed defaults |
| `certificate-option.service.ts` | Same pattern for create/update/new; `_seedDemoOptions()` properly typed |
| `manage-certificates.component.ts` | Form signal typed as `CertificateData`; all bracket access replaced |
| `manage-certificates.component.html` | `cert.data?.['field']` → `cert.data?.field` |
| `manage-options.component.ts` | Form typed as `CertificateOptionData`; bracket access replaced |
| `manage-options.component.html` | `opt.data?.['field']` → `opt.data?.field` |
| `certificate.component.html` | All three template styles (modern, minimalist, classic) use dot notation |
| `certificate-pdf.service.ts` | Bracket access replaced with dot notation |

## Explicit fields sent to backend

### Certificate create/update payload

```json
{
  "_id": "...",
  "name": "Recipient Name",
  "description": "Certificate Title",
  "data": {
    "title": "Сертифікат про завершення курсу",
    "recipientName": "Іван Іванов",
    "description": "За успішне проходження повного курсу...",
    "issueDate": "2026-04-13T10:00",
    "templateStyle": "classic"
  }
}
```

### CertificateOption create/update payload

```json
{
  "_id": "...",
  "data": {
    "title": "Сертифікат про завершення курсу",
    "description": "За успішне проходження...",
    "templateStyle": "classic"
  }
}
```

## Testing

- [x] Production build passes without compile errors
- [x] All static routes prerender correctly (31 routes)
- [x] Manual testing: create a certificate via `/manage/certificates`
- [x] Manual testing: edit an existing certificate
- [x] Manual testing: apply a template option
- [x] Manual testing: create/edit template options via `/manage/manage-options`
- [x] Manual testing: view a certificate detail page (`/certificate/:id`)
- [x] Manual testing: export certificate as PDF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data structure consistency across certificate and option management, enhancing type safety and data validation with standardized field definitions and default values.
  
* **Chores**
  * Updated configuration to exclude additional files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->