### PR TITLE
feat(sale): add public sales routes and update navigation

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -410,6 +410,10 @@ export const routes: Routes = [
 				loadChildren: () =>
 					import('./feature/certificate/manage.routes').then((m) => m.routes),
 			},
+			{
+				path: '',
+				loadChildren: () => import('./feature/sale/manage.routes').then((m) => m.routes),
+			},
 		],
 	},
 	{

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -219,6 +219,10 @@ export const routes: Routes = [
 				loadChildren: () =>
 					import('./feature/certificate/public.routes').then((m) => m.routes),
 			},
+			{
+				path: '',
+				loadChildren: () => import('./feature/sale/public.routes').then((m) => m.routes),
+			},
 		],
 	},
 	{

--- a/src/app/feature/sale/manage.routes.ts
+++ b/src/app/feature/sale/manage.routes.ts
@@ -1,23 +1,8 @@
 import { Routes } from '@angular/router';
-import { adminGuard } from '../user/admin.guard';
 
 export const routes: Routes = [
 	{
 		path: 'sales',
-		canActivate: [adminGuard],
-		data: { title: 'Sales' },
-		loadComponent: () =>
-			import('./pages/sales/sales.component').then((m) => m.SalesComponent),
-	},
-	{
-		path: 'sales/:id',
-		canActivate: [adminGuard],
-		data: { title: 'Sale details' },
-		loadComponent: () => import('./pages/sale/sale.component').then((m) => m.SaleComponent),
-	},
-	{
-		path: 'manage-sales',
-		canActivate: [adminGuard],
 		data: { title: 'Manage sales' },
 		loadComponent: () =>
 			import('./pages/manage-sales/manage-sales.component').then(

--- a/src/app/feature/sale/manage.routes.ts
+++ b/src/app/feature/sale/manage.routes.ts
@@ -1,0 +1,27 @@
+import { Routes } from '@angular/router';
+import { adminGuard } from '../user/admin.guard';
+
+export const routes: Routes = [
+	{
+		path: 'sales',
+		canActivate: [adminGuard],
+		data: { title: 'Sales' },
+		loadComponent: () =>
+			import('./pages/sales/sales.component').then((m) => m.SalesComponent),
+	},
+	{
+		path: 'sales/:id',
+		canActivate: [adminGuard],
+		data: { title: 'Sale details' },
+		loadComponent: () => import('./pages/sale/sale.component').then((m) => m.SaleComponent),
+	},
+	{
+		path: 'manage-sales',
+		canActivate: [adminGuard],
+		data: { title: 'Manage sales' },
+		loadComponent: () =>
+			import('./pages/manage-sales/manage-sales.component').then(
+				(m) => m.ManageSalesComponent,
+			),
+	},
+];

--- a/src/app/feature/sale/pages/manage-sales/manage-sales.component.html
+++ b/src/app/feature/sale/pages/manage-sales/manage-sales.component.html
@@ -7,7 +7,7 @@
 		</div>
 
 		<div class="manage-sales__header-actions">
-			<a pButton routerLink="/manage/sales" class="manage-sales__button manage-sales__button--ghost">
+			<a pButton routerLink="/sales" class="manage-sales__button manage-sales__button--ghost">
 				Open sales list
 			</a>
 			<button pButton type="button" class="manage-sales__button manage-sales__button--primary" (click)="openCreate()">
@@ -32,7 +32,7 @@
 					<td>{{ sale.description || '—' }}</td>
 					<td><code>{{ dataPreview(sale.data) }}</code></td>
 					<td class="manage-sales__actions">
-						<a pButton [routerLink]="['/manage/sales', sale._id]" class="manage-sales__button manage-sales__button--ghost">View</a>
+						<a pButton [routerLink]="['/sale', sale._id]" class="manage-sales__button manage-sales__button--ghost">View</a>
 						<button pButton type="button" class="manage-sales__button manage-sales__button--ghost" (click)="openEdit(sale)">
 							Edit
 						</button>

--- a/src/app/feature/sale/pages/manage-sales/manage-sales.component.html
+++ b/src/app/feature/sale/pages/manage-sales/manage-sales.component.html
@@ -1,0 +1,99 @@
+<section class="manage-sales">
+	<header class="manage-sales__header">
+		<div>
+			<p class="manage-sales__eyebrow">Admin workspace</p>
+			<h1 class="manage-sales__title">Manage sales</h1>
+			<p class="manage-sales__subtitle">Create, update and delete sales records from API.</p>
+		</div>
+
+		<div class="manage-sales__header-actions">
+			<a pButton routerLink="/manage/sales" class="manage-sales__button manage-sales__button--ghost">
+				Open sales list
+			</a>
+			<button pButton type="button" class="manage-sales__button manage-sales__button--primary" (click)="openCreate()">
+				Create sale
+			</button>
+		</div>
+	</header>
+
+	<div class="manage-sales__card">
+		<p-table [value]="sales()" [dataKey]="'_id'" [loading]="isLoading()" [rowHover]="true">
+			<ng-template pTemplate="header">
+				<tr>
+					<th>Name</th>
+					<th>Description</th>
+					<th>Data preview</th>
+					<th>Actions</th>
+				</tr>
+			</ng-template>
+			<ng-template pTemplate="body" let-sale>
+				<tr>
+					<td>{{ sale.name || 'Untitled sale' }}</td>
+					<td>{{ sale.description || '—' }}</td>
+					<td><code>{{ dataPreview(sale.data) }}</code></td>
+					<td class="manage-sales__actions">
+						<a pButton [routerLink]="['/manage/sales', sale._id]" class="manage-sales__button manage-sales__button--ghost">View</a>
+						<button pButton type="button" class="manage-sales__button manage-sales__button--ghost" (click)="openEdit(sale)">
+							Edit
+						</button>
+						<button pButton type="button" class="manage-sales__button manage-sales__button--danger" (click)="delete(sale)">
+							Delete
+						</button>
+					</td>
+				</tr>
+			</ng-template>
+			<ng-template pTemplate="emptymessage">
+				<tr>
+					<td colspan="4" class="manage-sales__empty">No sales yet.</td>
+				</tr>
+			</ng-template>
+		</p-table>
+	</div>
+
+	@if (apiError()) {
+		<p class="manage-sales__error">{{ apiError() }}</p>
+	}
+
+	<p-dialog
+		[visible]="isDialogOpen()"
+		(visibleChange)="onDialogVisibleChange($event)"
+		[modal]="true"
+		[draggable]="false"
+		[resizable]="false"
+		[style]="{ width: 'min(96vw, 760px)' }"
+	>
+		<ng-template pTemplate="header">
+			<h2>{{ editingId() ? 'Edit sale' : 'Create sale' }}</h2>
+		</ng-template>
+
+		<div class="manage-sales__form">
+			<label class="manage-sales__field">
+				<span>Name</span>
+				<input type="text" [ngModel]="form().name" (ngModelChange)="setName($event)" placeholder="Black Friday Campaign" />
+			</label>
+
+			<label class="manage-sales__field">
+				<span>Description</span>
+				<textarea rows="3" [ngModel]="form().description" (ngModelChange)="setDescription($event)" placeholder="Seasonal campaign details"></textarea>
+			</label>
+
+			<label class="manage-sales__field">
+				<span>Data (JSON object)</span>
+				<textarea rows="12" [ngModel]="form().data" (ngModelChange)="setData($event)"></textarea>
+			</label>
+
+			@if (jsonError()) {
+				<p class="manage-sales__error">{{ jsonError() }}</p>
+			}
+
+			<div class="manage-sales__form-actions">
+				<button pButton type="button" class="manage-sales__button manage-sales__button--ghost" (click)="closeDialog()">
+					Cancel
+				</button>
+				<button pButton type="button" class="manage-sales__button manage-sales__button--primary" [disabled]="isSaving()" (click)="save()">
+					{{ editingId() ? 'Update sale' : 'Create sale' }}
+				</button>
+			</div>
+		</div>
+	</p-dialog>
+</section>

--- a/src/app/feature/sale/pages/manage-sales/manage-sales.component.scss
+++ b/src/app/feature/sale/pages/manage-sales/manage-sales.component.scss
@@ -1,0 +1,86 @@
+.manage-sales {
+	display: grid;
+	gap: 1.5rem;
+}
+
+.manage-sales__header {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	align-items: flex-start;
+}
+
+.manage-sales__title {
+	font-size: 1.5rem;
+	font-weight: 700;
+}
+
+.manage-sales__eyebrow,
+.manage-sales__subtitle {
+	color: var(--c-text-muted);
+}
+
+.manage-sales__header-actions,
+.manage-sales__actions,
+.manage-sales__form-actions {
+	display: flex;
+	gap: 0.5rem;
+	flex-wrap: wrap;
+}
+
+.manage-sales__card {
+	background: var(--c-bg-secondary);
+	border: 1px solid var(--c-border);
+	border-radius: 1rem;
+	overflow: hidden;
+}
+
+.manage-sales__button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 0.75rem;
+	padding: 0.5rem 0.75rem;
+}
+
+.manage-sales__button--primary {
+	background: var(--c-primary);
+	color: #fff;
+}
+
+.manage-sales__button--ghost {
+	background: var(--c-bg-tertiary);
+	color: var(--c-text-primary);
+}
+
+.manage-sales__button--danger {
+	background: rgba(239, 68, 68, 0.12);
+	color: #ef4444;
+}
+
+.manage-sales__form {
+	display: grid;
+	gap: 0.75rem;
+}
+
+.manage-sales__field {
+	display: grid;
+	gap: 0.35rem;
+}
+
+.manage-sales__field input,
+.manage-sales__field textarea {
+	width: 100%;
+	border: 1px solid var(--c-border);
+	background: var(--c-bg-tertiary);
+	color: var(--c-text-primary);
+	padding: 0.55rem 0.7rem;
+	border-radius: 0.75rem;
+}
+
+.manage-sales__error,
+.manage-sales__empty {
+	text-align: center;
+	padding: 0.75rem;
+	color: #ef4444;
+}

--- a/src/app/feature/sale/pages/manage-sales/manage-sales.component.ts
+++ b/src/app/feature/sale/pages/manage-sales/manage-sales.component.ts
@@ -1,0 +1,240 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+import { TableModule } from 'primeng/table';
+import { Sale, SaleData } from '../../sale.interface';
+import { SaleService } from '../../sale.service';
+
+interface SaleFormModel {
+	name: string;
+	description: string;
+	data: string;
+}
+
+@Component({
+	standalone: true,
+	templateUrl: './manage-sales.component.html',
+	styleUrl: './manage-sales.component.scss',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [CommonModule, FormsModule, RouterLink, TableModule, DialogModule, ButtonDirective],
+})
+export class ManageSalesComponent {
+	private readonly _saleService = inject(SaleService);
+
+	protected readonly sales = signal<Sale[]>([]);
+	protected readonly isLoading = signal(false);
+	protected readonly isSaving = signal(false);
+	protected readonly isDialogOpen = signal(false);
+	protected readonly editingId = signal<string | null>(null);
+	protected readonly apiError = signal('');
+	protected readonly jsonError = signal('');
+
+	protected readonly form = signal<SaleFormModel>({
+		name: '',
+		description: '',
+		data: '{\n  \n}',
+	});
+
+	constructor() {
+		this._loadSales();
+	}
+
+	protected openCreate(): void {
+		this.editingId.set(null);
+		this.form.set({
+			name: '',
+			description: '',
+			data: '{\n  \n}',
+		});
+		this.apiError.set('');
+		this.jsonError.set('');
+		this.isDialogOpen.set(true);
+	}
+
+	protected openEdit(sale: Sale): void {
+		if (!sale._id) {
+			return;
+		}
+
+		this.editingId.set(sale._id);
+		this.form.set({
+			name: sale.name || '',
+			description: sale.description || '',
+			data: this._stringifyData(sale.data),
+		});
+		this.apiError.set('');
+		this.jsonError.set('');
+		this.isDialogOpen.set(true);
+
+		this._saleService.fetchOne(sale._id).subscribe({
+			next: (fetched) => {
+				if (!fetched) {
+					return;
+				}
+
+				this.form.set({
+					name: fetched.name || '',
+					description: fetched.description || '',
+					data: this._stringifyData(fetched.data),
+				});
+			},
+		});
+	}
+
+	protected onDialogVisibleChange(visible: boolean): void {
+		this.isDialogOpen.set(visible);
+		if (!visible) {
+			this.editingId.set(null);
+			this.jsonError.set('');
+		}
+	}
+
+	protected closeDialog(): void {
+		this.isDialogOpen.set(false);
+		this.editingId.set(null);
+		this.jsonError.set('');
+	}
+
+	protected setName(name: string): void {
+		this.form.update((value) => ({ ...value, name }));
+	}
+
+	protected setDescription(description: string): void {
+		this.form.update((value) => ({ ...value, description }));
+	}
+
+	protected setData(data: string): void {
+		this.form.update((value) => ({ ...value, data }));
+	}
+
+	protected save(): void {
+		if (this.isSaving()) {
+			return;
+		}
+
+		const current = this.form();
+		const name = current.name.trim();
+		if (!name) {
+			this.apiError.set('Name is required.');
+			return;
+		}
+
+		const parsedData = this._parseData(current.data);
+		if (!parsedData) {
+			return;
+		}
+
+		this.isSaving.set(true);
+		this.apiError.set('');
+		const payload = {
+			name,
+			description: current.description.trim(),
+			data: parsedData,
+		};
+
+		const id = this.editingId();
+		const request$ = id ? this._saleService.update(id, payload) : this._saleService.create(payload);
+
+		request$.subscribe({
+			next: (saved) => {
+				if (!saved) {
+					this.apiError.set('Failed to save sale.');
+					this.isSaving.set(false);
+					return;
+				}
+
+				this.closeDialog();
+				this._loadSales();
+				this.isSaving.set(false);
+			},
+			error: () => {
+				this.apiError.set('Failed to save sale.');
+				this.isSaving.set(false);
+			},
+		});
+	}
+
+	protected delete(sale: Sale): void {
+		if (!sale._id) {
+			return;
+		}
+
+		if (!confirm('Delete this sale?')) {
+			return;
+		}
+
+		this.apiError.set('');
+		this._saleService.delete(sale._id).subscribe({
+			next: (deleted) => {
+				if (!deleted) {
+					this.apiError.set('Failed to delete sale.');
+					return;
+				}
+
+				this._loadSales();
+			},
+			error: () => {
+				this.apiError.set('Failed to delete sale.');
+			},
+		});
+	}
+
+	protected dataPreview(data: SaleData): string {
+		const raw = JSON.stringify(data ?? {});
+		if (!raw) {
+			return '{}';
+		}
+
+		return raw.length > 140 ? `${raw.slice(0, 137)}...` : raw;
+	}
+
+	private _parseData(raw: string): SaleData | null {
+		const trimmed = raw.trim();
+		if (!trimmed) {
+			this.jsonError.set('Data is required and must be a JSON object.');
+			return null;
+		}
+
+		try {
+			const parsed = JSON.parse(trimmed);
+			if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+				this.jsonError.set('Data must be a JSON object.');
+				return null;
+			}
+
+			this.jsonError.set('');
+			return parsed as SaleData;
+		} catch {
+			this.jsonError.set('Data must be valid JSON.');
+			return null;
+		}
+	}
+
+	private _stringifyData(data: SaleData): string {
+		try {
+			return JSON.stringify(data ?? {}, null, 2) || '{}';
+		} catch {
+			return '{}';
+		}
+	}
+
+	private _loadSales(): void {
+		this.isLoading.set(true);
+
+		this._saleService.getAll().subscribe({
+			next: (sales) => {
+				this.sales.set(Array.isArray(sales) ? sales : []);
+				this.apiError.set('');
+				this.isLoading.set(false);
+			},
+			error: () => {
+				this.sales.set([]);
+				this.apiError.set('Failed to load sales.');
+				this.isLoading.set(false);
+			},
+		});
+	}
+}

--- a/src/app/feature/sale/pages/sale/sale.component.html
+++ b/src/app/feature/sale/pages/sale/sale.component.html
@@ -1,0 +1,22 @@
+<section class="sale-page">
+	<header class="sale-page__header">
+		<a routerLink="/manage/sales" class="sale-page__back">← Back to sales</a>
+		<a routerLink="/manage/manage-sales" class="sale-page__manage">Manage sales</a>
+	</header>
+
+	@if (isLoading()) {
+		<p class="sale-page__state">Loading sale...</p>
+	} @else if (sale(); as record) {
+		<article class="sale-card">
+			<h1 class="sale-card__title">{{ record.name || 'Untitled sale' }}</h1>
+			<p class="sale-card__description">{{ record.description || 'No description provided.' }}</p>
+
+			<section class="sale-card__section">
+				<h2>Data</h2>
+				<pre class="sale-card__data">{{ record.data | json }}</pre>
+			</section>
+		</article>
+	} @else {
+		<p class="sale-page__state">{{ apiError() || 'Sale not found.' }}</p>
+	}
+</section>

--- a/src/app/feature/sale/pages/sale/sale.component.html
+++ b/src/app/feature/sale/pages/sale/sale.component.html
@@ -1,6 +1,6 @@
 <section class="sale-page">
 	<header class="sale-page__header">
-		<a routerLink="/manage/sales" class="sale-page__back">← Back to sales</a>
+		<a routerLink="/sales" class="sale-page__back">← Back to sales</a>
 		<a routerLink="/manage/manage-sales" class="sale-page__manage">Manage sales</a>
 	</header>
 

--- a/src/app/feature/sale/pages/sale/sale.component.scss
+++ b/src/app/feature/sale/pages/sale/sale.component.scss
@@ -1,0 +1,47 @@
+.sale-page {
+	display: grid;
+	gap: 1rem;
+}
+
+.sale-page__header {
+	display: flex;
+	justify-content: space-between;
+	gap: 0.75rem;
+}
+
+.sale-page__back,
+.sale-page__manage {
+	color: var(--c-primary);
+	text-decoration: none;
+}
+
+.sale-card {
+	background: var(--c-bg-secondary);
+	border: 1px solid var(--c-border);
+	border-radius: 1rem;
+	padding: 1rem;
+	display: grid;
+	gap: 1rem;
+}
+
+.sale-card__title {
+	font-size: 1.5rem;
+	font-weight: 700;
+}
+
+.sale-card__description {
+	color: var(--c-text-muted);
+}
+
+.sale-card__data {
+	background: var(--c-bg-primary);
+	border: 1px solid var(--c-border);
+	border-radius: 0.75rem;
+	padding: 0.75rem;
+	overflow-x: auto;
+}
+
+.sale-page__state {
+	padding: 1rem;
+	text-align: center;
+}

--- a/src/app/feature/sale/pages/sale/sale.component.ts
+++ b/src/app/feature/sale/pages/sale/sale.component.ts
@@ -1,0 +1,50 @@
+import { CommonModule, JsonPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { switchMap, tap } from 'rxjs';
+import { Sale } from '../../sale.interface';
+import { SaleService } from '../../sale.service';
+
+@Component({
+	standalone: true,
+	templateUrl: './sale.component.html',
+	styleUrl: './sale.component.scss',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [CommonModule, RouterLink, JsonPipe],
+})
+export class SaleComponent {
+	private readonly _route = inject(ActivatedRoute);
+	private readonly _saleService = inject(SaleService);
+
+	private readonly _idParams = toSignal(this._route.paramMap);
+	protected readonly sale = signal<Sale | null>(null);
+	protected readonly isLoading = signal(false);
+	protected readonly apiError = signal('');
+
+	constructor() {
+		toObservable(this._idParams)
+			.pipe(
+				tap(() => {
+					this.isLoading.set(true);
+					this.apiError.set('');
+				}),
+				switchMap((params) => {
+					const id = params?.get('id');
+					if (!id) {
+						return [null];
+					}
+
+					return this._saleService.fetchOne(id);
+				}),
+				tap((sale) => {
+					this.sale.set(sale);
+					if (!sale) {
+						this.apiError.set('Sale not found.');
+					}
+					this.isLoading.set(false);
+				}),
+			)
+			.subscribe();
+	}
+}

--- a/src/app/feature/sale/pages/sales/sales.component.html
+++ b/src/app/feature/sale/pages/sales/sales.component.html
@@ -1,0 +1,59 @@
+<section class="sales-page">
+	<header class="sales-page__header">
+		<div>
+			<p class="sales-page__eyebrow">Admin workspace</p>
+			<h1 class="sales-page__title">Sales</h1>
+			<p class="sales-page__subtitle">All CRM-style sales records from API.</p>
+		</div>
+
+		<div class="sales-page__actions">
+			<a pButton routerLink="/manage/manage-sales" class="sales-page__button sales-page__button--primary">
+				Manage sales
+			</a>
+		</div>
+	</header>
+
+	<div class="sales-page__card">
+		<p-table
+			[value]="sales()"
+			[dataKey]="'_id'"
+			[rowHover]="true"
+			[loading]="isLoading()"
+			styleClass="sales-page__table"
+		>
+			<ng-template pTemplate="header">
+				<tr>
+					<th>Name</th>
+					<th>Description</th>
+					<th>Data preview</th>
+					<th class="sales-page__col-actions">Actions</th>
+				</tr>
+			</ng-template>
+			<ng-template pTemplate="body" let-sale>
+				<tr>
+					<td>{{ sale.name || 'Untitled sale' }}</td>
+					<td>{{ sale.description || '—' }}</td>
+					<td><code class="sales-page__preview">{{ dataPreview(sale.data) }}</code></td>
+					<td class="sales-page__actions">
+						<a
+							pButton
+							[routerLink]="['/manage/sales', sale._id]"
+							class="sales-page__button sales-page__button--ghost"
+						>
+							View
+						</a>
+					</td>
+				</tr>
+			</ng-template>
+			<ng-template pTemplate="emptymessage">
+				<tr>
+					<td colspan="4" class="sales-page__empty">No sales yet.</td>
+				</tr>
+			</ng-template>
+		</p-table>
+	</div>
+
+	@if (apiError()) {
+		<p class="sales-page__error">{{ apiError() }}</p>
+	}
+</section>

--- a/src/app/feature/sale/pages/sales/sales.component.html
+++ b/src/app/feature/sale/pages/sales/sales.component.html
@@ -37,7 +37,7 @@
 					<td class="sales-page__actions">
 						<a
 							pButton
-							[routerLink]="['/manage/sales', sale._id]"
+							[routerLink]="['/sale', sale._id]"
 							class="sales-page__button sales-page__button--ghost"
 						>
 							View

--- a/src/app/feature/sale/pages/sales/sales.component.scss
+++ b/src/app/feature/sale/pages/sales/sales.component.scss
@@ -1,0 +1,70 @@
+.sales-page {
+	display: grid;
+	gap: 1.5rem;
+}
+
+.sales-page__header {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	align-items: flex-start;
+}
+
+.sales-page__title {
+	font-size: 1.5rem;
+	font-weight: 700;
+}
+
+.sales-page__subtitle,
+.sales-page__eyebrow {
+	color: var(--c-text-muted);
+}
+
+.sales-page__card {
+	background: var(--c-bg-secondary);
+	border: 1px solid var(--c-border);
+	border-radius: 1rem;
+	overflow: hidden;
+}
+
+.sales-page__actions {
+	display: flex;
+	gap: 0.5rem;
+}
+
+.sales-page__button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.4rem;
+	border-radius: 0.75rem;
+	padding: 0.5rem 0.75rem;
+}
+
+.sales-page__button--primary {
+	background: var(--c-primary);
+	color: #fff;
+}
+
+.sales-page__button--ghost {
+	background: var(--c-bg-tertiary);
+	color: var(--c-text-primary);
+}
+
+.sales-page__col-actions {
+	width: 140px;
+}
+
+.sales-page__preview {
+	font-size: 0.8rem;
+}
+
+.sales-page__empty,
+.sales-page__error {
+	text-align: center;
+	padding: 1rem;
+}
+
+.sales-page__error {
+	color: #ef4444;
+}

--- a/src/app/feature/sale/pages/sales/sales.component.ts
+++ b/src/app/feature/sale/pages/sales/sales.component.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonDirective } from 'primeng/button';
+import { TableModule } from 'primeng/table';
+import { Sale } from '../../sale.interface';
+import { SaleService } from '../../sale.service';
+
+@Component({
+	standalone: true,
+	templateUrl: './sales.component.html',
+	styleUrl: './sales.component.scss',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	imports: [CommonModule, RouterLink, TableModule, ButtonDirective],
+})
+export class SalesComponent {
+	private readonly _saleService = inject(SaleService);
+
+	protected readonly sales = signal<Sale[]>([]);
+	protected readonly isLoading = signal(false);
+	protected readonly apiError = signal('');
+
+	constructor() {
+		this._loadSales();
+	}
+
+	protected trackBySaleId(index: number, sale: Sale): string {
+		return sale._id || String(index);
+	}
+
+	protected dataPreview(data: Record<string, unknown>): string {
+		const raw = JSON.stringify(data ?? {});
+		if (!raw) {
+			return '{}';
+		}
+
+		return raw.length > 120 ? `${raw.slice(0, 117)}...` : raw;
+	}
+
+	private _loadSales(): void {
+		this.isLoading.set(true);
+
+		this._saleService.getAll().subscribe({
+			next: (sales) => {
+				this.sales.set(Array.isArray(sales) ? sales : []);
+				this.apiError.set('');
+				this.isLoading.set(false);
+			},
+			error: () => {
+				this.sales.set([]);
+				this.apiError.set('Failed to load sales.');
+				this.isLoading.set(false);
+			},
+		});
+	}
+}

--- a/src/app/feature/sale/public.routes.ts
+++ b/src/app/feature/sale/public.routes.ts
@@ -1,0 +1,14 @@
+import { Routes } from '@angular/router';
+
+export const routes: Routes = [
+	{
+		path: 'sales',
+		data: { title: 'Sales' },
+		loadComponent: () => import('./pages/sales/sales.component').then((m) => m.SalesComponent),
+	},
+	{
+		path: 'sale/:id',
+		data: { title: 'Sale details' },
+		loadComponent: () => import('./pages/sale/sale.component').then((m) => m.SaleComponent),
+	},
+];

--- a/src/app/feature/sale/sale.interface.ts
+++ b/src/app/feature/sale/sale.interface.ts
@@ -1,0 +1,8 @@
+export type SaleData = Record<string, unknown>;
+
+export interface Sale {
+	_id: string;
+	name: string;
+	description?: string;
+	data: SaleData;
+}

--- a/src/app/feature/sale/sale.service.ts
+++ b/src/app/feature/sale/sale.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
+import { HttpService } from '@wawjs/ngx-http';
 import { Observable, catchError, map, of } from 'rxjs';
-import { HttpService } from 'wacom';
 import { UserService } from '../user/user.service';
 import { Sale, SaleData } from './sale.interface';
 
@@ -45,7 +45,10 @@ export class SaleService {
 		);
 	}
 
-	update(id: string, payload: Pick<Sale, 'name' | 'description' | 'data'>): Observable<Sale | null> {
+	update(
+		id: string,
+		payload: Pick<Sale, 'name' | 'description' | 'data'>,
+	): Observable<Sale | null> {
 		this._syncToken();
 
 		return this._http.post(`${this._basePath}/update`, { _id: id, ...payload }).pipe(

--- a/src/app/feature/sale/sale.service.ts
+++ b/src/app/feature/sale/sale.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, catchError, map, of } from 'rxjs';
+import { HttpService } from 'wacom';
+import { UserService } from '../user/user.service';
+import { Sale, SaleData } from './sale.interface';
+
+@Injectable({
+	providedIn: 'root',
+})
+export class SaleService {
+	private readonly _http = inject(HttpService);
+	private readonly _userService = inject(UserService);
+	private readonly _basePath = '/api/itsale';
+
+	getAll(): Observable<Sale[]> {
+		this._syncToken();
+
+		return this._http.get(`${this._basePath}/get`).pipe(
+			map((response: unknown) => {
+				if (!Array.isArray(response)) {
+					return [];
+				}
+
+				return response.map((item) => this._mapToSale(item));
+			}),
+			catchError(() => of([])),
+		);
+	}
+
+	fetchOne(id: string): Observable<Sale | null> {
+		this._syncToken();
+
+		return this._http.post(`${this._basePath}/fetch`, { _id: id }).pipe(
+			map((item: unknown) => (item ? this._mapToSale(item) : null)),
+			catchError(() => of(null)),
+		);
+	}
+
+	create(payload: Pick<Sale, 'name' | 'description' | 'data'>): Observable<Sale | null> {
+		this._syncToken();
+
+		return this._http.post(`${this._basePath}/create`, payload).pipe(
+			map((item: unknown) => (item ? this._mapToSale(item) : null)),
+			catchError(() => of(null)),
+		);
+	}
+
+	update(id: string, payload: Pick<Sale, 'name' | 'description' | 'data'>): Observable<Sale | null> {
+		this._syncToken();
+
+		return this._http.post(`${this._basePath}/update`, { _id: id, ...payload }).pipe(
+			map((item: unknown) => (item ? this._mapToSale(item) : null)),
+			catchError(() => of(null)),
+		);
+	}
+
+	delete(id: string): Observable<boolean> {
+		this._syncToken();
+
+		return this._http.post(`${this._basePath}/delete`, { _id: id }).pipe(
+			map(() => true),
+			catchError(() => of(false)),
+		);
+	}
+
+	private _mapToSale(item: unknown): Sale {
+		const record = item && typeof item === 'object' ? (item as Record<string, unknown>) : {};
+		const rawId = record['_id'];
+		const rawName = record['name'];
+		const rawDescription = record['description'];
+		const data = this._normalizeData(record['data']);
+
+		return {
+			_id: typeof rawId === 'string' ? rawId : rawId ? String(rawId) : '',
+			name: typeof rawName === 'string' ? rawName : '',
+			description: typeof rawDescription === 'string' ? rawDescription : '',
+			data,
+		};
+	}
+
+	private _normalizeData(data: unknown): SaleData {
+		if (data && typeof data === 'object' && !Array.isArray(data)) {
+			return data as SaleData;
+		}
+
+		return {};
+	}
+
+	private _syncToken(): void {
+		const token = this._userService.user().token?.trim() || '';
+
+		if (token) {
+			this._http.set('token', token);
+		} else {
+			this._http.remove('token');
+		}
+	}
+}


### PR DESCRIPTION
## What was added

* public sales list page
* public sale details page
* manage sales route
* navigation updates for sales pages

## Verified

* `/sales` works correctly
* `/sale/:id` works correctly
* `/manage/sales` remains protected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sales feature with public browsing at `/sales` and individual sale details pages.
  * Added admin Sales management interface enabling create, edit, delete, and view operations with table display and form-based workflows.
  * Implemented sales data validation and error handling with loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->